### PR TITLE
temp hack to repplace staticfiles tag that was removed in Django 3

### DIFF
--- a/extinctionr/settings.py
+++ b/extinctionr/settings.py
@@ -160,8 +160,11 @@ TEMPLATES = [
                 'sekizai.context_processors.sekizai', # for django-wiki
                 'django_mailman3.context_processors.common',
                 'postorius.context_processors.postorius',
-
             ],
+            'libraries': {
+                # Temp hack to fix CRM library. Django 3 removed staticfiles.
+                'staticfiles': 'django.templatetags.static'
+            }
         },
     },
 ]


### PR DESCRIPTION
The upgrade to Django 3 broke all the CRM code because they use the now obsolete 'staticfiles'. The hack solution was to put it back in settings by pointing it to static.
